### PR TITLE
修正进展报告页眉页脚为黑色

### DIFF
--- a/main_master_mid_report.tex
+++ b/main_master_mid_report.tex
@@ -124,8 +124,8 @@
 
 \pagestyle{fancy}
 \newgeometry{left=2.8cm,right=2.8cm,top=2.5cm,bottom=2.5cm}
-\chead{\zihao{-5}\color{gray}上海交通大学硕士论文中期检查报告~~Mid-term Examination for SJTU Master Student}
-\cfoot{\zihao{-5}\color{gray}\bfseries 1 / 1}
+\chead{\zihao{-5}上海交通大学硕士论文中期检查报告~~Mid-term Examination for SJTU Master Student}
+\cfoot{\zihao{-5}\bfseries 1 / 1}
 \fancyfootoffset{0pt}
 
 \begin{center}
@@ -171,7 +171,7 @@
 \clearpage
 \restoregeometry
 \setcounter{page}{1}
-\cfoot{\zihao{-5}\color{gray}\bfseries\thepage\ / \pageref*{LastPage}}
+\cfoot{\zihao{-5}\bfseries\thepage\ / \pageref*{LastPage}}
 \fancyfootoffset{0pt}
 
 \begin{center}

--- a/main_phd_mid_report.tex
+++ b/main_phd_mid_report.tex
@@ -125,7 +125,7 @@
 
 \pagestyle{fancy}
 \newgeometry{left=2.8cm,right=2.8cm,top=2.5cm,bottom=2.5cm}
-\chead{\zihao{-5}\color{gray}上海交通大学博士生年度进展报告~~Annual Progress Review for SJTU Doctoral Student}
+\chead{\zihao{-5}上海交通大学博士生年度进展报告~~Annual Progress Review for SJTU Doctoral Student}
 \cfoot{}
 \fancyfootoffset{0pt}
 
@@ -172,7 +172,7 @@
 \clearpage
 \restoregeometry
 \setcounter{page}{1}
-\cfoot{\zihao{-5}\color{gray}\bfseries\thepage\ / \pageref*{LastPage}}
+\cfoot{\zihao{-5}\bfseries\thepage\ / \pageref*{LastPage}}
 \fancyfootoffset{0pt}
 
 


### PR DESCRIPTION
页眉页脚应当是黑色的，Word 只是在 UI 视觉上将页眉页脚展示为灰色，但是双击页眉页脚预览/打印下来依旧是黑色的。